### PR TITLE
Add node_type geometry and material attributes

### DIFF
--- a/scripts/setup_db2.sh
+++ b/scripts/setup_db2.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Create node_types table
+aws rds-data execute-statement \
+    --resource-arn "$RESOURCE_ARN" \
+    --database "$DB" \
+    --secret-arn "$SECRET_ARN" \
+    --sql \
+    "CREATE TABLE IF NOT EXISTS node_types (
+       id int NOT NULL auto_increment,
+       name varchar(40) NOT NULL UNIQUE,
+       threejs_geometry varchar(40) NOT NULL,
+       threejs_geometry_attributes varchar(255) NOT NULL,
+       threejs_material varchar(40) NOT NULL,
+       threejs_material_attributes varchar(255) NOT NULL,
+       PRIMARY KEY (id)
+       );"
+
+# Add a default record
+aws rds-data execute-statement \
+ --resource-arn "$RESOURCE_ARN" \
+ --database "$DB" \
+ --secret-arn "$SECRET_ARN" \
+ --sql \
+ "INSERT INTO node_types (name, threejs_geometry, threejs_geometry_attributes, threejs_material, threejs_material_attributes)
+   VALUES
+       ('default','SphereGeometry','4,32,32','MeshStandardMaterial',
+       '{\"color\":\"#c2d31c\",\"emissive\":\"#42423e\",\"metalness\":0.5,\"roughness\":0.5}'
+       );"
+
+# Add another record
+aws rds-data execute-statement \
+ --resource-arn "$RESOURCE_ARN" \
+ --database "$DB" \
+ --secret-arn "$SECRET_ARN" \
+ --sql \
+ "INSERT INTO node_types (name, threejs_geometry, threejs_geometry_attributes, threejs_material, threejs_material_attributes)
+   VALUES
+       ('box','BoxGeometry','10,10,10','MeshStandardMaterial',
+       '{\"color\":\"#ff0000\",\"emissive\":\"#000000\",\"metalness\":0.5,\"roughness\":0.5}'
+       );"
+
+# Add one more
+aws rds-data execute-statement \
+ --resource-arn "$RESOURCE_ARN" \
+ --database "$DB" \
+ --secret-arn "$SECRET_ARN" \
+ --sql \
+ "INSERT INTO node_types (name, threejs_geometry, threejs_geometry_attributes, threejs_material, threejs_material_attributes)
+   VALUES
+       ('torusknot','TorusKnotGeometry','2,3.1,103,20,13,20','MeshStandardMaterial',
+       '{\"color\":\"#4dce21\",\"emissive\":\"#000000\",\"metalness\":0.5,\"roughness\":0.5}'
+       );"
+
+# Add a note_type foreign key to nodes
+aws rds-data execute-statement \
+   --resource-arn "$RESOURCE_ARN" \
+   --database "$DB" \
+   --secret-arn "$SECRET_ARN" \
+   --sql \
+   "ALTER TABLE nodes
+   ADD node_type_id int;"
+
+# Set node type to default on all existing nodes
+aws rds-data execute-statement \
+   --resource-arn "$RESOURCE_ARN" \
+   --database "$DB" \
+   --secret-arn "$SECRET_ARN" \
+   --sql \
+   "UPDATE nodes
+   SET node_type_id = 1;"
+
+# Add constraint to nodes
+aws rds-data execute-statement \
+   --resource-arn "$RESOURCE_ARN" \
+   --database "$DB" \
+   --secret-arn "$SECRET_ARN" \
+   --sql \
+   "ALTER TABLE nodes
+   ADD CONSTRAINT fk_node_type_id FOREIGN KEY (node_type_id) REFERENCES node_types (id);"

--- a/src/nodes/nodes.ts
+++ b/src/nodes/nodes.ts
@@ -14,10 +14,18 @@ const params = {
 export class Node {
   id: number;
   name: string;
+  threejs_geometry: string;
+  threejs_geometry_attributes: string;
+  threejs_material: string;
+  threejs_material_attributes: string;
 
-  constructor(id: number, name: string) {
+  constructor(id: number, name: string, threejs_geometry: string, threejs_geometry_attributes: string, threejs_material: string, threejs_material_attributes: string) {
     this.id = id;
     this.name = name;
+    this.threejs_geometry = threejs_geometry;
+    this.threejs_geometry_attributes = threejs_geometry_attributes;
+    this.threejs_material = threejs_material;
+    this.threejs_material_attributes = threejs_material_attributes;
   }
 }
 
@@ -30,14 +38,14 @@ export async function get(req: Request, res: Response): Promise<Response> {
 
 export async function GetNodes(linkedApps: number[]): Promise<Node[]> {
 
-    let query = "SELECT id, name FROM nodes WHERE id IN (" + linkedApps.toString() + ")"
+    let query = "SELECT nodes.id, nodes.name, threejs_geometry, threejs_geometry_attributes, threejs_material, threejs_material_attributes FROM service_topology.nodes INNER JOIN service_topology.node_types ON nodes.node_type_id = node_types.id  WHERE nodes.id IN (" + linkedApps.toString() + ")"
 
     const db = new RDSDatabase(params).getInstance();
     const results = await db.query(query);
 
     let nodes:Node[] = [];
     results.data.forEach((node) => {
-      nodes.push(new Node(<number> node.id.number, <string> node.name.string));
+      nodes.push(new Node(<number> node.id.number, <string> node.name.string, <string> node.threejs_geometry.string, <string> node.threejs_geometry_attributes.string, <string> node.threejs_material.string, <string> node.threejs_material_attributes.string ));
     });
 
     return nodes;

--- a/src/public/javascripts/graph.js
+++ b/src/public/javascripts/graph.js
@@ -47,23 +47,8 @@ const Graph = ForceGraph3D()
       const threejs_geometry_attributes=node.threejs_geometry_attributes.split(',');
       const threejs_material_attributes=JSON.parse(node.threejs_material_attributes);
 
-      switch (threejs_geometry_attributes.length) {
-        case 3:
-          threejs_geometry_object = new THREE[node.threejs_geometry](threejs_geometry_attributes[0],threejs_geometry_attributes[1],threejs_geometry_attributes[2]);
-          break;
-        case 4:
-          threejs_geometry_object = new THREE[node.threejs_geometry](threejs_geometry_attributes[0],threejs_geometry_attributes[1],threejs_geometry_attributes[2],threejs_geometry_attributes[3]);
-          break;
-        case 5:
-          threejs_geometry_object = new THREE[node.threejs_geometry](threejs_geometry_attributes[0],threejs_geometry_attributes[1],threejs_geometry_attributes[2],threejs_geometry_attributes[3],threejs_geometry_attributes[4]);
-          break;
-        case 6:
-          threejs_geometry_object = new THREE[node.threejs_geometry](threejs_geometry_attributes[0],threejs_geometry_attributes[1],threejs_geometry_attributes[2],threejs_geometry_attributes[3],threejs_geometry_attributes[4],threejs_geometry_attributes[5]);
-          break;
-      }
-
       const obj = new THREE.Mesh(
-        threejs_geometry_object,
+        new THREE[node.threejs_geometry](...threejs_geometry_attributes),
         new THREE[node.threejs_material](JSON.parse(node.threejs_material_attributes))
       );
 

--- a/src/public/javascripts/graph.js
+++ b/src/public/javascripts/graph.js
@@ -44,9 +44,27 @@ let hoverNode = null;
 const Graph = ForceGraph3D()
     .nodeThreeObject(node => {
       // use a sphere as a drag handle
+      const threejs_geometry_attributes=node.threejs_geometry_attributes.split(',');
+      const threejs_material_attributes=JSON.parse(node.threejs_material_attributes);
+
+      switch (threejs_geometry_attributes.length) {
+        case 3:
+          threejs_geometry_object = new THREE[node.threejs_geometry](threejs_geometry_attributes[0],threejs_geometry_attributes[1],threejs_geometry_attributes[2]);
+          break;
+        case 4:
+          threejs_geometry_object = new THREE[node.threejs_geometry](threejs_geometry_attributes[0],threejs_geometry_attributes[1],threejs_geometry_attributes[2],threejs_geometry_attributes[3]);
+          break;
+        case 5:
+          threejs_geometry_object = new THREE[node.threejs_geometry](threejs_geometry_attributes[0],threejs_geometry_attributes[1],threejs_geometry_attributes[2],threejs_geometry_attributes[3],threejs_geometry_attributes[4]);
+          break;
+        case 6:
+          threejs_geometry_object = new THREE[node.threejs_geometry](threejs_geometry_attributes[0],threejs_geometry_attributes[1],threejs_geometry_attributes[2],threejs_geometry_attributes[3],threejs_geometry_attributes[4],threejs_geometry_attributes[5]);
+          break;
+      }
+
       const obj = new THREE.Mesh(
-        new THREE.SphereGeometry(4),
-        new THREE.MeshBasicMaterial({ depthWrite: false, opacity: 70 })
+        threejs_geometry_object,
+        new THREE[node.threejs_material](JSON.parse(node.threejs_material_attributes))
       );
 
       // add text sprite as child


### PR DESCRIPTION
Adds node_types table with fields for:
- threejs_geometry
- threejs_geometry_attributes
- threejs_material
- threejs_material_attributes

Also adds a node_type_id foreign key to the nodes table.

This allows different nodes to be given different shapes and colours.

For reference:
- Material: https://threejs.org/docs/#api/en/materials/Material
- Geometry: https://threejs.org/docs/#api/en/core/Geometry
- Example of Sphere Geometry: https://threejs.org/docs/#api/en/geometries/SphereGeometry
